### PR TITLE
Fixed aspect ratio error

### DIFF
--- a/GithubContributionGraphExample/ContentView.swift
+++ b/GithubContributionGraphExample/ContentView.swift
@@ -73,9 +73,8 @@ struct ContentView: View {
         }
         let firstDate = contributions.first!.date
         let lastDate = contributions.last!.date
-        let firstWeek = Calendar.current.component(.weekOfYear, from: firstDate)
-        let lastWeek = Calendar.current.component(.weekOfYear, from: lastDate)
-        return Double(lastWeek - firstWeek + 1) / 7
+        let weeksCount = Calendar.current.dateComponents([.weekOfYear], from: firstDate, to: lastDate).weekOfYear!
+        return Double(weeksCount + 1) / 7
     }
 
     private var colors: [Color] {


### PR DESCRIPTION
The computation for aspect ratio was incorrect. 

It was based on the number of weeks from the start of the year, but this does not work if the first date is in year 1 and last date is in year 2. 

I fixed it by instead getting the number of weeks between the two dates.